### PR TITLE
DATA-772: update rexster configuration instructions to reference proper imports

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -81,7 +81,8 @@ Edit conf/rexster-cassandra-es.xml (or the configuration file you're using) in y
 
 
 There should already be a script-engine defined for gremlin-groovy.   You can just copy that section and change the name
-to gremlin-python.  All of the other values can remain the same.
+to gremlin-python.  Replace "com.tinkerpop.gremlin.groovy." in the new script-engine section for
+gremlin-python to be "com.pokitdok.gremlin.python."  All of the other values can remain the same.
 
 You'll also need to drop the files gremlin-python-{version}.jar and jython-standalone-{version}.jar
 into your titan lib directory.   gremlin-python has been tested with jython-standalone-2.7-b3.jar.


### PR DESCRIPTION
@tim-d-blue discovered an issue with the current rexster configuration instructions.   Including more detail there.   We'll likely provide a script to automate the installation in the future.