### PR TITLE
DATA-771: use ClassLoader to avoid issues sourcing gremthon.py in deployed environments

### DIFF
--- a/src/main/java/com/pokitdok/gremlin/python/jsr223/GremlinPythonScriptEngineFactory.java
+++ b/src/main/java/com/pokitdok/gremlin/python/jsr223/GremlinPythonScriptEngineFactory.java
@@ -5,8 +5,10 @@ import org.python.jsr223.PyScriptEngineFactory;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
+import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -63,7 +65,8 @@ public class GremlinPythonScriptEngineFactory extends PyScriptEngineFactory {
         try {
             engine = super.getScriptEngine();
             //Load up gremthon for use within this Python script engine
-            engine.eval(new FileReader("gremthon.py"));
+            ClassLoader engineClassLoader = GremlinPythonScriptEngineFactory.class.getClassLoader();
+            engine.eval(new BufferedReader(new InputStreamReader(engineClassLoader.getResourceAsStream("gremthon.py"))));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
@tim-d-blue noticed these exceptions being raised when starting up titan

```
java.io.FileNotFoundException: gremthon.py (No such file or directory)
    at java.io.FileInputStream.open(Native Method)
    at java.io.FileInputStream.<init>(FileInputStream.java:138)
    at java.io.FileInputStream.<init>(FileInputStream.java:93)
    at java.io.FileReader.<init>(FileReader.java:58)
    at com.pokitdok.gremlin.python.jsr223.GremlinPythonScriptEngineFactory.getScriptEngine(GremlinPythonScriptEngineFactory.java:66)
```

Using the ClassLoader seems to resolve that.