### PR TITLE
DATA-773: add repr support for Gremthon objects

### DIFF
--- a/gremthon.py
+++ b/gremthon.py
@@ -437,6 +437,9 @@ class Gremthon(object):
     def __enter__(self):
         return self
 
+    def __repr__(self):
+        return self.graph.toString()
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.graph.shutdown()
 

--- a/src/test/java/com/pokitdok/gremlin/python/jsr223/GremlinPythonScriptEngineFactoryTest.java
+++ b/src/test/java/com/pokitdok/gremlin/python/jsr223/GremlinPythonScriptEngineFactoryTest.java
@@ -29,15 +29,11 @@ public class GremlinPythonScriptEngineFactoryTest {
     }
 
     @Test
-    public void testPipeline() throws ScriptException, FileNotFoundException {
+    public void testPythonSuite() throws ScriptException, FileNotFoundException {
         ScriptEngineManager manager = new ScriptEngineManager();
         ScriptEngine engine = manager.getEngineByName("gremlin-python");
 
-        engine.eval("from inspect import isfunction");
-        engine.eval(new FileReader("tests/test_pipeline.py"));
-        engine.eval("pipeline_tests = [v for k, v in dict(locals()).items() if isfunction(v) and k.startswith('test_')]");
-        engine.eval("pipeline_tests = sorted(pipeline_tests, key=lambda f: f.func_code.co_firstlineno)");
-        engine.eval("[pipeline_test() for pipeline_test in pipeline_tests]");
+        engine.eval(new FileReader("tests/run_all.py"));
     }
 
 }

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -1,0 +1,15 @@
+#utility script to run all tests within a `mvn test` run
+import glob
+import imp
+from inspect import isfunction
+import os
+
+for module_file_path in glob.glob('tests/*.py'):
+    module_path, module_filename = os.path.split(module_file_path)
+    if module_filename.startswith('test_'):
+        module_name, file_ext = os.path.splitext(module_filename)
+        module = imp.load_source(module_name, module_file_path)
+        test_functions = [getattr(module, attr) for attr in dir(module) if isfunction(getattr(module, attr)) and attr.startswith('test_')]
+        test_functions = sorted(test_functions, key=lambda f: f.func_code.co_firstlineno)
+        for test_function in test_functions:
+            test_function()

--- a/tests/test_gremthon.py
+++ b/tests/test_gremthon.py
@@ -1,0 +1,15 @@
+from gremthon import Gremthon
+
+#Java imports
+from com.tinkerpop.blueprints.impls.tg import TinkerGraphFactory
+
+graph = TinkerGraphFactory.createTinkerGraph()
+g = Gremthon(graph)
+
+
+def test_gremthon_repr():
+    """
+        Verify repr of a gremthon wrapped graph
+    """
+    assert str(g) == 'tinkergraph[vertices:6 edges:6]'
+


### PR DESCRIPTION
These changes enable this:
```
$ ~/jython2.7b3/bin/jython -i gremthon.py
>>> g
tinkergraph[vertices:6 edges:6]
>>>
```